### PR TITLE
Feature/sns 221

### DIFF
--- a/src/app/pages/HomePage/FilterTab/components/__tests__/__snapshots__/ResultItem.test.tsx.snap
+++ b/src/app/pages/HomePage/FilterTab/components/__tests__/__snapshots__/ResultItem.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`<ResultItem /> should render and match the snapshot 1`] = `
   </styled.h3>
   <styled.div>
     <styled.span>
-      2021-08-18
+      2021-08-20
     </styled.span>
   </styled.div>
 </styled.div>


### PR DESCRIPTION
Hi @jweisbaum  @markomakaric.  

I have fixed your pull request comments: 
A few improvements:
- Make map/list selection persistent between visits. If I was on the list view, when I come back I should be on the list view. 
- Base of flags should be at end points of lines or where the marks are. Right now it’s the center of the flag images that’s above the mark or the endpoint location, not their bases.
- Remove email from sharing link.
- Add WeChat share if possible. Not sure how they do things.
- Add back button in top right to go back to search results.
- Limit zooming out too far.

And added test snapshots & test for the redux saga