### PR TITLE
SNS-471 [Hotfix] Fix a bug when searching at caret position.

### DIFF
--- a/src/app/pages/HomePage/components/MapViewTab/components/ResultSuggestion.tsx
+++ b/src/app/pages/HomePage/components/MapViewTab/components/ResultSuggestion.tsx
@@ -42,7 +42,7 @@ export const ResultSuggestion = (props) => {
         let criteriaMatched: any[] = [];
         let searchKeyWord = keyword.slice(0, keyword.indexOf(' ', caretPosition.current));
 
-        if (keyword.indexOf(' ', caretPosition.current)) searchKeyWord = keyword;
+        if (keyword.indexOf(' ', caretPosition.current) === -1) searchKeyWord = keyword;
 
         const searchKeyWordAsArray = searchKeyWord.split(' ');
 


### PR DESCRIPTION
There is a bug when searching at caret position. It's not using word at caret. Instead it uses the last word of the whole search string. This pull is a hotfix for it.