### PR TITLE
Fix course polygon not the same after create & update using course ed…

### DIFF
--- a/src/app/pages/CourseCreateUpdatePage/components/MapViewTab/MapView.tsx
+++ b/src/app/pages/CourseCreateUpdatePage/components/MapViewTab/MapView.tsx
@@ -293,7 +293,7 @@ export const MapView = React.forwardRef((props, ref) => {
                                 });
                             });
                             if (geometryType === GEOMETRY_TYPE.polygon) { // polygon only, making this polygon first position & last position the same as discussed with Aan.
-                                makeSureFirstPointAndLastPointOfPolygonAreTheSame(geometry);
+                                enclosePolygonPoints(geometry);
                             }
                             break;
                     }
@@ -336,7 +336,7 @@ export const MapView = React.forwardRef((props, ref) => {
                             })
                         });
                     });
-                    makeSureFirstPointAndLastPointOfPolygonAreTheSame(geometry);
+                    enclosePolygonPoints(geometry);
                     layer.options._geometry_type = GEOMETRY_TYPE.polygon;
                     break;
                 case LAYER_TYPE.polyline:
@@ -361,7 +361,7 @@ export const MapView = React.forwardRef((props, ref) => {
         });
     }
 
-    const makeSureFirstPointAndLastPointOfPolygonAreTheSame = (geometry) => {
+    const enclosePolygonPoints = (geometry) => {
         const firstPoint = geometry?.points[0];
         const lastPoint = geometry?.points[geometry?.points?.length - 1];
         if (firstPoint?.position[0] !== lastPoint?.position[0] &&


### PR DESCRIPTION
[Webapp]
Course creation : 
when creating polygon, validate that first and last point is the exact same lat,lon
