### PR TITLE
Remove interpolate position for marks as it does not necessary.

### DIFF
--- a/src/app/pages/PlaybackPage/workers/old-race-map-frame-data.js
+++ b/src/app/pages/PlaybackPage/workers/old-race-map-frame-data.js
@@ -56,18 +56,6 @@ const workercode = () => {
             if (!lastPosition) // eslint-disable-next-line
                 return;
 
-            const isRetrievedTimestampExist = retrievedTimestamps.includes(selectedTimestamp);
-            if (!isRetrievedTimestampExist) {
-                // Only interpolate when no timestamp available
-                const nearestPos = findNearestPositions(point.tracks, selectedTimestamp, 1000, { excludeSelectedTimestamp: true });
-                const interpolatedPosition = interpolateNearestPositions(nearestPos, selectedTimestamp);
-
-                if (interpolatedPosition) {
-                    lastPosition.lat = interpolatedPosition.lat;
-                    lastPosition.lon = interpolatedPosition.lon;
-                }
-            }
-
             return Object.assign({}, point, { position: [lastPosition.lat, lastPosition.lon] });
         }).filter(Boolean);
 


### PR DESCRIPTION
The issue was caused by interpolating marks positions when they do not exist in the timeline. And the playback calculated some of them wrong => malformed lon lat position, the playback crash and try to re-draw the course -> blinking line. I removed the interpolate logic for marks as it's not necessary.