### PR TITLE
SNS-1277 [Fix] Include source import to show modal data is being processed for imported track

### DIFF
--- a/src/app/pages/PlaybackPage/components/ModalDataIsBeingProcessed.tsx
+++ b/src/app/pages/PlaybackPage/components/ModalDataIsBeingProcessed.tsx
@@ -27,7 +27,7 @@ export const ModalDataIsBeingProcessed = () => {
     const playbackType = useSelector(selectPlaybackType);
 
     React.useEffect(() => {
-        if (competitionUnitDetail.calendarEvent?.source === RaceSource.SYRF
+        if ([RaceSource.SYRF, RaceSource.IMPORT].includes(competitionUnitDetail.calendarEvent?.source)
             && competitionUnitDetail.status === RaceStatus.COMPLETED) {
             clearIntervalIfNecessary();
             if (!competitionUnitDetail.isSavedByEngine) {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -291,7 +291,8 @@ export enum GroupTypes {
 }
 
 export enum RaceSource {
-    SYRF = 'SYRF'
+    SYRF = 'SYRF',
+    IMPORT = 'IMPORT'
 }
 
 export const sourcesPreventIframe = ['TACKTRACKER'];


### PR DESCRIPTION
This issue is created because when the data is being processed by BE so it's not available to play yet.
The solution is to show the modal race is being processed and renew the data after an interval.