### PR TITLE
SNS-1396 [Fix] Fix boats disappear on the playback occasionally

### DIFF
--- a/src/app/pages/PlaybackPage/components/PlaybackOldrace.tsx
+++ b/src/app/pages/PlaybackPage/components/PlaybackOldrace.tsx
@@ -127,7 +127,6 @@ export const PlaybackOldRace = (props) => {
     // Get old race additional data
     if (competitionUnitDetail?.id) {
       dispatch(actions.getOldRaceData({ raceId: competitionUnitDetail.id }));
-      getSimplifiedTracks();
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -165,6 +164,7 @@ export const PlaybackOldRace = (props) => {
   // Set vessel participants, update format to object
   useEffect(() => {
     if (vesselParticipants?.length) {
+      getSimplifiedTracks();
       const vesselParticipantsObject = {};
       vesselParticipants.forEach((vesselParticipant) => {
         // Set new participant data


### PR DESCRIPTION
- The bug happened because when getting simplified tracks the vesselParticipants data is being delayed, simplified tracks data comes first and vesselParticipants data comes after. So that when mapping simplified tracks, there is no vesselParticipants at the time to map => it returns empty array of timeline.